### PR TITLE
fix: re-add templates_dir to environment variables

### DIFF
--- a/src/profi/profi.py
+++ b/src/profi/profi.py
@@ -105,6 +105,7 @@ def main(template: str):
 
     # Change directory to templates
     templates_dir = os.path.expanduser(config["templates_dir"])
+    os.environ["OP_TEMPLATES_DIR"] = templates_dir
     available_templates = get_available_templates(templates_dir)
 
     if template:


### PR DESCRIPTION
This re-adds the environment variable for the template directory. Without this variable, templates accessing this directory are not populated.