### PR TITLE
feat: use `ip` to get attacker ip

### DIFF
--- a/src/profi/templates/variables/attacker_ip
+++ b/src/profi/templates/variables/attacker_ip
@@ -1,1 +1,1 @@
-<%=${OP_ATTACKER_IP:-$(ifconfig $(esh variables/attacker_interface) | grep 'inet ' | cut -d' ' -f10 | tr -d '[:space:]')}%>
+<%=${OP_ATTACKER_IP:-$(ip -f inet addr show $(esh variables/attacker_interface) | awk '/inet / {print $2}' | cut -d/ -f1)}%>


### PR DESCRIPTION
This gets the attacker IP via `ip` instead of `ifconfig` because it is deprecated. 